### PR TITLE
Set m5ops_addr to enable m5 exits, minor fixes

### DIFF
--- a/configs/disk-image-configs/finalize.sh
+++ b/configs/disk-image-configs/finalize.sh
@@ -22,4 +22,11 @@ touch /etc/cloud/cloud-init.disabled
 sudo update-alternatives --set iptables /usr/sbin/iptables-legacy
 sudo update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
 
+## Disable other unnecessary services
+systemctl disable systemd-modules-load.service
+systemctl disable multipathd.service
+systemctl disable apt-daily-upgrade.timer
+
+apt update && apt upgrade -y
+
 shutdown -h now

--- a/gem5utils/systems/drive/system.py
+++ b/gem5utils/systems/drive/system.py
@@ -93,6 +93,10 @@ class DriveSystem(System):
 
         self.workload.command_line = ' '.join(boot_options)
 
+        # Set m7ops_base address to enable m5 binary to exit from kvm
+        # Default in intel is 0xffff0000
+        self.m5ops_base = int("ffff0000",16)
+
         # Create the CPUs for our system.
         print("Drive system: {} {} cores".format(1,DriveCPUClass))
         self.createCPU()

--- a/gem5utils/systems/simple/system.py
+++ b/gem5utils/systems/simple/system.py
@@ -84,6 +84,10 @@ class SimpleSystem(System):
 
         self.workload.command_line = ' '.join(boot_options)
 
+        # Set m7ops_base address to enable m5 binary to exit from kvm
+        # Default in intel is 0xffff0000
+        self.m5ops_base = int("ffff0000",16)
+
         # Create the CPU for our system.
         self.createCPU(num_cpus=num_cpus, CPUModel=CPUModel)
 

--- a/gem5utils/systems/skylake/system.py
+++ b/gem5utils/systems/skylake/system.py
@@ -85,6 +85,10 @@ class SklSystem(System):
 
         self.workload.command_line = ' '.join(boot_options)
 
+        # Set m7ops_base address to enable m5 binary to exit from kvm
+        # Default in intel is 0xffff0000
+        self.m5ops_base = int("ffff0000",16)
+
         # Create the CPU for our system.
         self.createCPU(num_cpus=num_cpus, CPUModel=CPUModel)
         # Create the CPUs for our system.

--- a/setup/gem5.Makefile
+++ b/setup/gem5.Makefile
@@ -29,7 +29,7 @@ ROOT 		:= $(abspath $(dir $(mkfile_path))/../)
 ## User specific inputs
 RESOURCES 	?=$(ROOT)/resources/
 ARCH		:= X86
-VERSION     := v21.2.1.1
+VERSION     := v22.0.0.1
 
 GEM5_DIR 	?= $(RESOURCES)/gem5/
 GEM5 		:= $(GEM5_DIR)/build/$(ARCH)/gem5.opt
@@ -61,6 +61,7 @@ $(GEM5_DIR):
 gem5: $(GEM5_DIR)
 	@$(call print_config)
 	cd $(GEM5_DIR); \
+	git checkout $(VERSION); \
 	scons build/$(ARCH)/gem5.opt -j $$(nproc) --install-hooks
 
 

--- a/simulation/install_functions.sh
+++ b/simulation/install_functions.sh
@@ -2,7 +2,7 @@
 
 set -x
 
-LOGFILE=install.log
+LOGFILE=/root/install.log
 
 function start_logging {
   ## Log everything to a empty log file
@@ -24,8 +24,8 @@ function pull_test_function {
     echo "Install and test: ${FUNCTION_NAME} "
 
     ## Pull the image from regestry
-    docker-compose -f functions.yaml pull ${FUNCTION_NAME}
-    docker-compose -f functions.yaml up -d --remove-orphans ${FUNCTION_NAME}
+    docker-compose -f /root/functions.yaml pull ${FUNCTION_NAME}
+    docker-compose -f /root/functions.yaml up -d --remove-orphans ${FUNCTION_NAME}
 
     sleep 5
 
@@ -55,14 +55,14 @@ curl  "http://10.0.2.2:3003/test-client" -f -o /root/test-client
 chmod 755 /root/test-client
 
 ## Download the function yaml and list.
-curl  "http://10.0.2.2:3003/functions.yaml" -f -o functions.yaml
-curl  "http://10.0.2.2:3003/functions.list" -f -o functions.list
+curl  "http://10.0.2.2:3003/functions.yaml" -f -o /root/functions.yaml
+curl  "http://10.0.2.2:3003/functions.list" -f -o /root/functions.list
 
 
 # docker-compose -f functions.yaml pull
 
 ## List all functions can be commented out
-FUNCTIONS=$(cat functions.list | sed '/^\s*#/d;/^\s*$/d')
+FUNCTIONS=$(cat /root/functions.list | sed '/^\s*#/d;/^\s*$/d')
 
 for f in $FUNCTIONS
   do
@@ -74,7 +74,6 @@ for f in $FUNCTIONS
   echo "\033[0;31m----------------"
   echo "FAIL"
   echo "----------------\033[0m"
-  cat results.log
 }
 # set +e
 end_logging

--- a/simulation/wkdir-tmpl/run_sim.tmpl.py
+++ b/simulation/wkdir-tmpl/run_sim.tmpl.py
@@ -71,7 +71,7 @@ m5 fail 1 ## 1: BOOTING complete
 
 ## Spin up Container
 echo "Start the container..."
-docker-compose -f functions.yaml up -d {FN_NAME}
+docker-compose -f /root/functions.yaml up -d {FN_NAME}
 m5 fail 2 ## 2: Started container
 
 echo "Pin function container to core 1"
@@ -101,7 +101,7 @@ m5 fail 11 ## 11: Stop client
 
 
 ## Stop container
-docker-compose -f functions.yaml down
+docker-compose -f /root/functions.yaml down
 m5 fail 6 ## 6: Container stop
 
 

--- a/simulation/wkdir-tmpl/run_sim_two_machine.tmpl.py
+++ b/simulation/wkdir-tmpl/run_sim_two_machine.tmpl.py
@@ -196,7 +196,7 @@ ifconfig {device_name} {test_ip}
 
 ## Spin up Container
 echo "Start the container..."
-docker-compose -f functions.yaml up -d {function}
+docker-compose -f /root/functions.yaml up -d {function}
 m5 fail 2 ## 2: Started container
 
 echo "Pin function container to core {cpu}"

--- a/tools/client/main.go
+++ b/tools/client/main.go
@@ -48,7 +48,7 @@ var (
 	url            = flag.String("url", "0.0.0.0", "The url to connect to")
 	port           = flag.String("port", "50051", "the port to connect to")
 	input          = flag.String("input", defaultInput, "Input to the function")
-	functionMethod = flag.String("function-method", "default", "Which method of benchmark to invoke")
+	functionMethod = flag.String("function-method", "0", "Which method of benchmark to invoke")
 	numInvoke      = flag.Int("n", 10, "Number of invocations")
 	numWarm        = flag.Int("w", 0, "Number of invocations for warming")
 	logfile        = flag.String("logging", "", "Log to file instead of standart out")


### PR DESCRIPTION
* Since version v22.x the default m5ops_addr is omitted.
Now the address range is set explicitly.
* Use absolute paths in install scripts.
* Disable services that fail during booting
* Fix test-client. Use "0" as default method

Signed-off-by: David Schall <d.h.schall@sms.ed.ac.uk>